### PR TITLE
```text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ out/
 
 # Ignores development broadcast logs
 !/broadcast
+/broadcast
+
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 


### PR DESCRIPTION
refactor: Ignore /broadcast directory in .gitignore

The .gitignore file has been updated to ignore the /broadcast directory. This change ensures that the directory and its contents are not tracked by Git.